### PR TITLE
Remove cl-lib from dependencies

### DIFF
--- a/fix-input.el
+++ b/fix-input.el
@@ -5,7 +5,7 @@
 ;; Author: Mark Karpov <markkarpov@openmailbox.org>
 ;; URL: https://github.com/mrkkrp/fix-input
 ;; Version: 0.1.0
-;; Package-Requires: ((emacs "24.4") (cl-lib "0.5"))
+;; Package-Requires: ((emacs "24.4"))
 ;; Keywords: input method
 ;;
 ;; This file is not part of GNU Emacs.


### PR DESCRIPTION
Emacs 24.4 bundles cl-lib.el.
